### PR TITLE
fix: Miro board link for Bobby's DSA notes

### DIFF
--- a/docs/courses/cis2101/resources/index.md
+++ b/docs/courses/cis2101/resources/index.md
@@ -8,7 +8,7 @@ title: 'Resources'
 
 - [Samuel Bonghanoy's DSA-practice GitHub Repository](https://github.com/Samuel-Bonghanoy/DSA-practice/tree/master/DSA) - contains implementations of the various data structures & algorithms.
 - [Mary Modesto's DSA Notes](https://drive.google.com/drive/folders/1oftaWQGD4w5fsqUk4RhQDhCLXWLglZc7?usp=sharing) - a Google Drive containing implementations for Cursor-based, Hashing, and Sets
-- [Fabiola Villanueva's Miro Board for DSA] - an in-depth digital whiteboard of all the diagrams, notes, and sample code encountered in DSA.
+- [Fabiola Villanueva's Miro Board for DSA](https://miro.com/app/board/uXjVKGSc5oY=/?share_link_id=442891376991) - an in-depth digital whiteboard of all the diagrams, notes, and sample code encountered in DSA.
 
 ## Practice Exams
 


### PR DESCRIPTION
Added/Updated bobby's Miro board link only

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Problem Context

Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Replacing the video for X section", explain why the change is necessary. -->

There was no clickable link to view the Miro board itself.

## Solution

Explain how you addressed the Problem Context outlined previously.

<!-- You can skip this if you're fixing a typo or updating links. -->

I added the view access link for the board by just following the format from the rest.

## Closing Issues

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
